### PR TITLE
Implemented usePicoRouter– a small router hook that uses browser history

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -868,6 +868,12 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+      "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+      "dev": true
+    },
     "@svgr/core": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-2.4.1.tgz",
@@ -4518,6 +4524,36 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
+        }
+      }
+    },
+    "dom-testing-library": {
+      "version": "3.16.8",
+      "resolved": "https://registry.npmjs.org/dom-testing-library/-/dom-testing-library-3.16.8.tgz",
+      "integrity": "sha512-VGn2piehGoN9lmZDYd+xoTZwwcS+FoXebvZMw631UhS5LshiLTFNJs9bxRa9W7fVb1cAn9AYKAKZXh67rCDaqw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.1.5",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "pretty-format": "^24.0.0",
+        "wait-for-expect": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+          "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "24.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.0.0.tgz",
+          "integrity": "sha512-LszZaKG665djUcqg5ZQq+XzezHLKrxsA86ZABTozp+oNhkdqa+tG2dX4qa6ERl5c/sRDrAa3lHmwnvKoP+OG/g==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0"
+          }
         }
       }
     },
@@ -14205,6 +14241,33 @@
         "workbox-webpack-plugin": "3.6.3"
       }
     },
+    "react-testing-library": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-testing-library/-/react-testing-library-5.8.0.tgz",
+      "integrity": "sha512-cYOX8aUKea5ojFVXkhLbNEAq86nYqBlhKulJI/0v8JfwWyQm+kbyNKFfyci6b2qI4KUEvBYZKWx+zZWeYrYOOA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "dom-testing-library": "^3.13.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
+          "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+          "dev": true
+        }
+      }
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -16839,6 +16902,12 @@
         "webidl-conversions": "^4.0.2",
         "xml-name-validator": "^3.0.0"
       }
+    },
+    "wait-for-expect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.1.0.tgz",
+      "integrity": "sha512-vQDokqxyMyknfX3luCDn16bSaRcOyH6gGuUXMIbxBLeTo6nWuEWYqMTT9a+44FmW8c2m6TRWBdNvBBjA1hwEKg==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.7",

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,7 @@
     "typescript": "3.3.3"
   },
   "devDependencies": {
+    "react-testing-library": "^5.8.0",
     "tslint": "^5.12.1",
     "tslint-react-hooks": "^1.1.0"
   },

--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -9,9 +9,10 @@ import Header from './Header/Header';
 import About from './About/About';
 import Footer from './Footer/Footer';
 import './App.css';
+import  usePicoRouter, { Routes } from './usePicoRouter';
 
 const App = () => {
-  const [view, setView] = useState<string>('CTA');
+  const [route, setRoute] = usePicoRouter({ default: 'find' });
   const [position, getPosition] = useGeolocation();
   const [sensors, setSensors] = useState<SensorData[]>([]);
   const [nearest, setNearest] = useState<SensorData>({
@@ -25,22 +26,22 @@ const App = () => {
 
   const handleClick = async () => {
     await getPosition();
-    setView('Sensor');
+    setRoute('sensor');
   };
 
   const sensor = findNearestSensor(position.coords, sensors);
   if (sensor !== nearest) setNearest(sensor);
 
-  const views: { [key: string]: JSX.Element } = {
-    Sensor: <Sensor {...nearest}></Sensor>,
-    CTA: <CTA onClick={handleClick}></CTA>,
-    About: <About></About>
+  const routes: Routes = {
+    sensor: <Sensor {...nearest}></Sensor>,
+    find: <CTA onClick={handleClick}></CTA>,
+    about: <About></About>
   };
 
   return (
     <div className='app'>
-      <Header goTo={setView}></Header>
-      {views[view]}
+      <Header goTo={setRoute}></Header>
+      {routes[route]}
       <Footer coords={position.coords}></Footer>
     </div>
   );

--- a/client/src/components/Header/Header.tsx
+++ b/client/src/components/Header/Header.tsx
@@ -8,16 +8,18 @@ interface HeaderProps {
 const Header = React.memo((props: HeaderProps) => {
   return (
     <header>
-      <a className='logo' onClick={() => props.goTo('CTA')}>Dallas Rain Report</a>
+      <a className='logo' onClick={() => props.goTo('find')}>
+        Dallas Rain Report
+      </a>
       <nav>
         <ul className='views'>
           <li>
-            <a onClick={() => props.goTo('CTA')}>
+            <a onClick={() => props.goTo('find')}>
               Report
             </a>
           </li>
           <li>
-            <a onClick={() => props.goTo('About')}>
+            <a onClick={() => props.goTo('about')}>
               About
             </a>
           </li>

--- a/client/src/components/useGeolocation.ts
+++ b/client/src/components/useGeolocation.ts
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 type GeolocationHook = [Position, (options?: PositionOptions) => Promise<Position>];
 
@@ -7,31 +7,33 @@ const defaults: PositionOptions = {
   enableHighAccuracy: true
 };
 
+const start: Position = {
+  coords: {
+    accuracy: 0,
+    altitude: null,
+    altitudeAccuracy: null,
+    heading: null,
+    latitude: 0,
+    longitude: 0,
+    speed: null
+  },
+  timestamp: 0
+};
+
 const useGeolocation = (): GeolocationHook => {
-  const [position, setPosition] = useState<Position>({
-    coords: {
-      accuracy: 0,
-      altitude: null,
-      altitudeAccuracy: null,
-      heading: null,
-      latitude: 0,
-      longitude: 0,
-      speed: null
-    },
-    timestamp: 0
-  });
+  const [position, setPosition] = useState<Position>(start);
 
   const getCurrentPosition = (options: PositionOptions) => new Promise((resolve, reject) => {
     navigator.geolocation.getCurrentPosition(resolve, reject, { ...options, ...defaults });
   });
 
-  const getPosition = async (options: PositionOptions = {}) => {
+  const fetchPosition = async (options: PositionOptions = {}) => {
     const current = await getCurrentPosition(options) as Position;
     setPosition(current);
     return position;
   };
 
-  return [position, getPosition];
+  return [position, fetchPosition];
 };
 
 export default useGeolocation;

--- a/client/src/components/usePicoRouter.test.tsx
+++ b/client/src/components/usePicoRouter.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import usePicoRouter from './usePicoRouter';
+import { render, cleanup, fireEvent, testHook } from 'react-testing-library';
+import { act } from 'react-dom/test-utils';
+
+afterEach(cleanup);
+
+it('it provides a setRoute function that accepts a string', () => {
+  let route: any;
+  let setRoute: any;
+
+  // https://bit.ly/2V7uuBh
+  testHook(() => {
+    // tslint:disable-next-line
+    return ([route, setRoute] = usePicoRouter({ default: 'default' }));
+  });
+
+  expect(route).toBe('default');
+
+  act(() => {
+    setRoute('bar');
+  });
+
+  expect(route).toBe('bar');
+});
+
+test('setRoute pushes to the browser history api', () => {
+  const Test = () => {
+    const [_, setRoute] = usePicoRouter({ default: 'default' });
+    return <button onClick={() => setRoute('foo')}></button>;
+  };
+
+  const { container } = render(<Test />);
+  const button = container.querySelector('button') as HTMLElement;
+  fireEvent.click(button);
+  expect(history.state.route).toBe('foo');
+});
+
+it(`predictably propogates changes to route property during render`, () => {
+  const Test = () => {
+    const [route, setRoute] = usePicoRouter({ default: 'default' });
+    return (
+      <div>
+        <button onClick={() => setRoute('bar')}></button>
+        <div id='route'>{route}</div>
+      </div>
+    );
+  };
+
+  const { container } = render(<Test />);
+  const button = container.querySelector('button') as HTMLElement;
+  const route = container.querySelector('#route') as HTMLElement;
+  fireEvent.click(button);
+  expect(route.innerHTML).toBe('bar');
+});
+

--- a/client/src/components/usePicoRouter.ts
+++ b/client/src/components/usePicoRouter.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+
+export type PicoRouterHook = [string, (route: string) => void];
+
+export interface Routes {
+  [route: string]: JSX.Element;
+}
+
+export interface RouterConfig {
+  default: string;
+}
+
+const usePicoRouter = (config: RouterConfig): PicoRouterHook => {
+  const [route, setRoute] = useState<string>(config.default);
+
+  const handleBack = (event: PopStateEvent) => {
+    setRoute(event.state.route);
+  };
+
+  useEffect(() => {
+    window.addEventListener('popstate', handleBack);
+    return function cleanup() {
+      window.removeEventListener('popstate', handleBack);
+    };
+  });
+
+  const withHistory = (fn: Function) => (route: string) => {
+    history.pushState({ route }, `${route} page`, route);
+    fn(route);
+  };
+
+  return [route, withHistory(setRoute)];
+};
+
+export default usePicoRouter;


### PR DESCRIPTION
- `route` and `setRoute` let you create naive routes with that work using the browser's [history api](https://developer.mozilla.org/en-US/docs/Web/API/History)
- `Routes` is a type for the route map:
```
const routes: Routes = {
   route: <View></View>
};
```